### PR TITLE
Adding support for non-static MAC learning entry

### DIFF
--- a/ofprotocol/ofp13/ofp13_parser.go
+++ b/ofprotocol/ofp13/ofp13_parser.go
@@ -538,6 +538,34 @@ func NewOfpFlowModAdd(
 	)
 }
 
+func NewOfpFlowModAddNonStatic(
+	cookie uint64,
+	cookieMask uint64,
+	tableId uint8,
+	priority uint16,
+	flags uint16,
+	idleTimeout uint16,
+	hardTimeout uint16,
+	match *OfpMatch,
+	instructions []OfpInstruction,
+) *OfpFlowMod {
+	return newOfpFlowMod(
+		cookie,
+		cookieMask,
+		tableId,
+		OFPFC_ADD,
+		idleTimeout, // idle timeout, 0 means permanent
+		hardTimeout, // hard timeout, 0 means permanent
+		priority,
+		OFP_NO_BUFFER,
+		OFPP_ANY,
+		OFPG_ANY,
+		flags,
+		match,
+		instructions,
+	)
+}
+
 func NewOfpFlowModModify(
 	cookie uint64,
 	cookieMask uint64,


### PR DESCRIPTION
NewOfpFlowModAddNonStatic() - Adding support for flow entry 'idle_timeout' second.