### PR TITLE
Multicast Ethernet Mask fix

### DIFF
--- a/ofprotocol/ofp13/ofp13_parser.go
+++ b/ofprotocol/ofp13/ofp13_parser.go
@@ -1835,7 +1835,7 @@ func (m *OxmEth) Serialize() []byte {
 
 	if oxmHasMask(m.TlvHeader) == 1 {
 		for i := 0; i < 6; i++ {
-			packet[index] = m.Mask[0]
+			packet[index] = m.Mask[i]
 			index++
 		}
 	}

--- a/ofprotocol/ofp13/ofp13_parser_test.go
+++ b/ofprotocol/ofp13/ofp13_parser_test.go
@@ -756,6 +756,30 @@ func TestParseOxmMatchEthDst(t *testing.T) {
 	}
 }
 
+//Multicast ethernet match testing
+func TestSerializeOxmMatchMulticastEthDstW(t *testing.T) {
+	expect := []byte{
+		0x80, 0x00, // Class(OFPXMC_OPENFLOW_BASIC)
+		0x07,                               // OFPXMT_OFB_ETH_DST, Has mask is true
+		0x0c,                               // Length
+		0x01, 0x00, 0x00, 0x00, 0x00, 0x00, // Value
+		0x01, 0x00, 0x00, 0x00, 0x00, 0x00, // Mask
+	}
+	e_str := hex.EncodeToString(expect)
+
+	// reset xid for test
+	xid = 0
+
+	oxm, _ := NewOxmEthDstW("01:00:00:00:00:00", "01:00:00:00:00:00")
+	actual := oxm.Serialize()
+	a_str := hex.EncodeToString(actual)
+	if len(expect) != len(actual) || e_str != a_str {
+		t.Log("Expected Value is : ", e_str)
+		t.Log("Actual Value is   : ", a_str)
+		t.Error("Serialized binary of OxmEthDst is not equal to expected value.")
+	}
+}
+
 func TestSerializeOxmMatchEthDstW(t *testing.T) {
 	expect := []byte{
 		0x80, 0x00, // Class(OFPXMC_OPENFLOW_BASIC)
@@ -4063,7 +4087,7 @@ func TestParsePacketIn(t *testing.T) {
 		0x00, 0x23, 0x20, 0x90, 0x00, 0x00,
 		0x00, 0x00, 0x00, 0x00,
 	}
-	packet := append(packetInWithoutReceivedData,receivedData...)
+	packet := append(packetInWithoutReceivedData, receivedData...)
 
 	m := NewOfpPacketIn()
 	m.Parse(packet)
@@ -4077,7 +4101,7 @@ func TestParsePacketIn(t *testing.T) {
 		m.Match.OxmFields[0].(*OxmInPort).TlvHeader != OXM_OF_IN_PORT ||
 		m.Match.OxmFields[0].(*OxmInPort).Value != 0xfffffffe ||
 		len(m.Data) != len(receivedData) ||
-		!bytes.Equal(m.Data,receivedData) {
+		!bytes.Equal(m.Data, receivedData) {
 		t.Log("Version        : ", m.Header.Version)
 		t.Log("Type           : ", m.Header.Type)
 		t.Log("Length         : ", m.Header.Length)


### PR DESCRIPTION
OxmEth Serialize() is fixed to output the correct mask for multicast Ethernet.

Multicast ethernet mask's first octet is copied to all other octets due to hard-coded index. Added unit test and updated the code for the proposed solution.
