### PR TITLE
increased receiver buffer size to accommodate multiple segmented message handling

### DIFF
--- a/datapath.go
+++ b/datapath.go
@@ -45,7 +45,7 @@ func (dp *Datapath) sendLoop() {
 }
 
 func (dp *Datapath) recvLoop() {
-	buf := make([]byte, 1024*64)
+	buf := make([]byte, 1024*256)
 	for {
 		// read
 		size, err := dp.conn.Read(buf)
@@ -58,6 +58,10 @@ func (dp *Datapath) recvLoop() {
 		// tmp := make([]byte, 2048)
 		for i := 0; i < size; {
 			msgLen := binary.BigEndian.Uint16(buf[i+2:])
+			if msgLen < 1 || i+(int)(msgLen) > size {
+				fmt.Println("msgLen is 0 or exceeding size")
+				break
+			}
 			dp.handlePacket(buf[i : i+(int)(msgLen)])
 			i += (int)(msgLen)
 		}

--- a/ofprotocol/ofp13/ofp13_parser.go
+++ b/ofprotocol/ofp13/ofp13_parser.go
@@ -1385,7 +1385,7 @@ func (m *OfpMatch) Size() int {
 	for _, e := range m.OxmFields {
 		size += e.Size()
 	}
-	size += (8 - (size % 8))
+	size += (8 - (size % 8)) & 7 // add 0~7 bytes padding
 	return size
 }
 


### PR DESCRIPTION


when received packet size is more than 65536(1024x64), code crashes with invalid index access error. increased the buffer size to 1024x256 to accommodate big packet handling. Also added a check on the msgLen to avoid the unexpected panic scenario on accessing the invalid index.